### PR TITLE
use cheap-source-map in webpack dev mode

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,5 +8,5 @@ module.exports = merge(common, {
     noInfo: true,
     overlay: true
   },
-  devtool: '#eval-source-map'
+  devtool: '#cheap-source-map'
 });


### PR DESCRIPTION
fixes dev mode due to new Nextcloud csp rules