### PR TITLE
Fix handling of empty resourcetype

### DIFF
--- a/src/models/davCollection.js
+++ b/src/models/davCollection.js
@@ -346,7 +346,7 @@ export class DavCollection extends DAVEventListener {
 			const url = this._request.pathname(path);
 
 			// empty resourcetype property => this is no collection
-			if (props['{DAV:}resourcetype'].length === 0) {
+			if ((!props['{DAV:}resourcetype']) || (props['{DAV:}resourcetype'].length === 0)) {
 				debug(`${path} was identified as a file`);
 
 				const contentType = props['{DAV:}getcontenttype'].split(';')[0];


### PR DESCRIPTION
The resourcetype may be undefined, not just have length 0, for non-collections.

Closes #336 