### PR TITLE
Implement deleted calendar collection

### DIFF
--- a/src/models/deletedCalendar.js
+++ b/src/models/deletedCalendar.js
@@ -1,0 +1,32 @@
+/**
+ * CDAV Library
+ *
+ * This library is part of the Nextcloud project
+ *
+ * @author Richard Steinmetz
+ * @copyright 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { Calendar } from './calendar';
+
+/**
+ * This class represents a deleted calendar collection.
+ *
+ * @augments Calendar
+ */
+export class DeletedCalendar extends Calendar {
+}


### PR DESCRIPTION
Required for implementing https://github.com/nextcloud/calendar/issues/3175.

## Problem
The color of a deleted calendar should be shown in the trash bin. Currently, a deleted calendar is parsed as a default DAV collection and does not expose its color property.

## Solution
Implement a dummy `DeletedCalendar` class which just extends `Calendar` and register it with `CalendarHome`. Now a deleted calendar is parsed correctly and exports the same properties as a normal calendar.

## Alternative (hacky)
Extract the required color property manually. 

```js
const color = deletedCalendar._props['{http://apple.com/ns/ical/}calendar-color']
```