### PR TITLE
Remove private field from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "cdav-library",
-	"version": "0.0.1",
+	"name": "@nextcloud/cdav-library",
+	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "cdav-library",
-			"version": "0.0.1",
+			"name": "@nextcloud/cdav-library",
+			"version": "1.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"core-js": "^3.19.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	],
 	"author": "Georg Ehrke",
 	"license": "AGPL-3.0",
-	"private": true,
 	"bugs": {
 		"url": "https://github.com/nextcloud/cdav-library/issues"
 	},


### PR DESCRIPTION
Followup to #600 

The package can't be published otherwise.

Also updates the package-lock.json with the changes from the publish
preparations.