### PR TITLE
Only match display name in advanced prop search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -308,8 +308,7 @@ export default class DavClient {
 				children: [{
 					name: [NS.DAV, 'prop'],
 					children: [
-						{ name: [NS.DAV, 'displayname'] },
-						{ name: [NS.SABREDAV, 'email-address'] }
+						{ name: [NS.DAV, 'displayname'] }
 					]
 				}, {
 					name: [NS.DAV, 'match'],


### PR DESCRIPTION
We use `allof` for resource searches to prevent excessive search results. However, we also try to match the given display name against the actual display name *AND* the email of a resource. If the email address does not contain the display name this will never produce any results. In the context of searching resources it doesn't make much sense to also search in email addresses.

The advanced property search method is exclusively used for searching rooms and resources so this is safe change. You can use https://github.com/search?q=org%3Anextcloud+advancedPrincipalPropertySearch&type=code to quickly verify that.