### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default class DavClient {
 		 */
 		this.rootUrl = null;
 
-		if (options.rootUrl.substr(-1) !== '/') {
+		if (options.rootUrl.slice(-1) !== '/') {
 			options.rootUrl += '/';
 		}
 

--- a/src/models/davCollection.js
+++ b/src/models/davCollection.js
@@ -42,7 +42,7 @@ export class DavCollection extends DAVEventListener {
 		super();
 
 		// This is a collection, so always make sure to end with a /
-		if (url.substr(-1) !== '/') {
+		if (url.slice(-1) !== '/') {
 			url += '/';
 		}
 

--- a/src/models/principal.js
+++ b/src/models/principal.js
@@ -66,9 +66,9 @@ export class Principal extends DavObject {
 			principalScheme: {
 				get: () => {
 					const baseUrl = this._request.pathname(this._request.baseUrl);
-					let principalURI = this.url.substr(baseUrl.length);
-					if (principalURI.substr(-1) === '/') {
-						principalURI = principalURI.substr(0, principalURI.length - 1);
+					let principalURI = this.url.slice(baseUrl.length);
+					if (principalURI.slice(-1) === '/') {
+						principalURI = principalURI.slice(0, -1);
 					}
 
 					return 'principal:' + principalURI;

--- a/src/parser.js
+++ b/src/parser.js
@@ -286,13 +286,13 @@ export default class Parser {
 	static iCalendarTimestamp(document, node, resolver) {
 		const text = Parser.text(document, node, resolver);
 
-		const year = parseInt(text.substr(0, 4), 10);
-		const month = parseInt(text.substr(4, 2), 10) - 1;
-		const date = parseInt(text.substr(6, 2), 10);
+		const year = parseInt(text.slice(0, 4), 10);
+		const month = parseInt(text.slice(4, 6), 10) - 1;
+		const date = parseInt(text.slice(6, 8), 10);
 
-		const hour = parseInt(text.substr(9, 2), 10);
-		const minute = parseInt(text.substr(11, 2), 10);
-		const second = parseInt(text.substr(13, 2), 10);
+		const hour = parseInt(text.slice(9, 11), 10);
+		const minute = parseInt(text.slice(11, 13), 10);
+		const second = parseInt(text.slice(13, 15), 10);
 
 		const dateObj = new Date();
 		dateObj.setUTCFullYear(year, month, date);
@@ -542,7 +542,7 @@ export default class Parser {
 		// but some browsers can't parse that *cough cough* Safari 9 *cough cough*
 		// Safari 10 seems to support this though
 		if (text.length === 9) {
-			return text.substr(0, 7);
+			return text.slice(0, 7);
 		}
 
 		return text;

--- a/src/request.js
+++ b/src/request.js
@@ -410,12 +410,12 @@ export default class Request {
 	 */
 	filename(url) {
 		let pathname = this.pathname(url);
-		if (pathname.substr(-1) === '/') {
-			pathname = pathname.substr(0, pathname.length - 1);
+		if (pathname.slice(-1) === '/') {
+			pathname = pathname.slice(0, -1);
 		}
 
 		const slashPos = pathname.lastIndexOf('/');
-		return pathname.substr(slashPos);
+		return pathname.slice(slashPos);
 	}
 
 	/**

--- a/src/utility/stringUtility.js
+++ b/src/utility/stringUtility.js
@@ -85,8 +85,8 @@ export function uri(start, isAvailable) {
 	// === false because !undefined = true, possible infinite loop
 	do {
 		const positionLastDash = uri.lastIndexOf('-');
-		const firstPart = uri.substr(0, positionLastDash);
-		let lastPart = uri.substr(positionLastDash + 1);
+		const firstPart = uri.slice(0, positionLastDash);
+		let lastPart = uri.slice(positionLastDash + 1);
 
 		if (lastPart.match(/^\d+$/)) {
 			lastPart = parseInt(lastPart);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.