### PR TITLE
fix: add child to schedule-calendar-transp property

### DIFF
--- a/src/propset/calendarPropSet.js
+++ b/src/propset/calendarPropSet.js
@@ -88,7 +88,9 @@ export default function calendarPropSet(props) {
 		case '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp':
 			xmlified.push({
 				name: [NS.IETF_CALDAV, 'schedule-calendar-transp'],
-				value,
+				children: [{
+					name: [NS.IETF_CALDAV, value],
+				}],
 			})
 			break
 		default:

--- a/test/unit/propset/calendarPropSetTest.js
+++ b/test/unit/propset/calendarPropSetTest.js
@@ -118,4 +118,36 @@ describe('Calendar prop-set', () => {
 			}
 		]);
 	});
+
+	it('should serialize {urn:ietf:params:xml:ns:caldav}schedule-calendar-transp correctly - transparent', () => {
+		expect(calendarPropSet({
+			'{Foo:}bar': 123,
+			'{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp': 'transparent'
+		})).toEqual([
+			{
+				name: ['urn:ietf:params:xml:ns:caldav', 'schedule-calendar-transp'],
+				children: [
+					{
+						name: ['urn:ietf:params:xml:ns:caldav', 'transparent'],
+					},
+				],
+			}
+		]);
+	});
+
+	it('should serialize {urn:ietf:params:xml:ns:caldav}schedule-calendar-transp correctly - opaque', () => {
+		expect(calendarPropSet({
+			'{Foo:}bar': 123,
+			'{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp': 'opaque'
+		})).toEqual([
+			{
+				name: ['urn:ietf:params:xml:ns:caldav', 'schedule-calendar-transp'],
+				children: [
+					{
+						name: ['urn:ietf:params:xml:ns:caldav', 'opaque'],
+					},
+				],
+			}
+		]);
+	});
 });


### PR DESCRIPTION
Looks like the RFC defines a child property:

https://datatracker.ietf.org/doc/html/rfc6638#section-9.1