### PR TITLE
feat: serialize namespaced attributes consistently across browsers 

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        run: npx playwright install firefox --with-deps
+        run: npx playwright install --with-deps webkit chromium firefox
 
       - name: Test
         run: npm run test

--- a/src/utility/xmlUtility.js
+++ b/src/utility/xmlUtility.js
@@ -70,7 +70,7 @@ function xmlify(xmlDoc, parent, json) {
 			element.setAttribute(name, value)
 		} else {
 			const [namespace, localName, value] = attribute
-			element.setAttributeNS(namespace, localName, value)
+			element.setAttributeNS(namespace, getPrefixedNameForNamespace(namespace, localName), value)
 		}
 	})
 

--- a/test/unit/utility/xmlUtilityTest.js
+++ b/test/unit/utility/xmlUtilityTest.js
@@ -8,6 +8,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { server } from '@vitest/browser/context';
 
 import * as XMLUtility from '../../../src/utility/xmlUtility.js';
 
@@ -42,13 +43,21 @@ describe('XMLUtility', () => {
 	});
 
 	it('should return correct xml for one element with namespaced attributes', () => {
+		let expectedXml = '<x0:element xmlns:x0="NS123" xmlns:x1="myNs1" x1:abc="123" xmlns:x2="myNs2" x2:def="456"/>'
+		if (server.browser === 'firefox') {
+			// As of now, Firefox orders the XML attributes differently than Chromium and WebKit.
+			// It uses the namespace `x1` in the attribute `x1:abc="123"` before declaring it with `xmlns:x1="myNs1"`.
+			// It is legal XML but does not follow the specification of XML serialization described in https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring
+			// See https://bugzilla.mozilla.org/show_bug.cgi?id=1837472
+			expectedXml = '<x0:element xmlns:x0="NS123" x1:abc="123" xmlns:x1="myNs1" x2:def="456" xmlns:x2="myNs2"/>';
+		}
 		expect(XMLUtility.serialize({
 			name: ['NS123', 'element'],
 			attributes: [
 				['myNs1', 'abc', '123'],
 				['myNs2', 'def', '456']
 			]
-		})).toEqual('<x0:element xmlns:x0="NS123" x1:abc="123" xmlns:x1="myNs1" x2:def="456" xmlns:x2="myNs2"/>');
+		})).toEqual(expectedXml);
 	});
 
 	it('should return correct xml for one element with attributes and value', () => {

--- a/test/unit/utility/xmlUtilityTest.js
+++ b/test/unit/utility/xmlUtilityTest.js
@@ -41,6 +41,16 @@ describe('XMLUtility', () => {
 		})).toEqual('<x0:element xmlns:x0="NS123" abc="123" def="456"/>');
 	});
 
+	it('should return correct xml for one element with namespaced attributes', () => {
+		expect(XMLUtility.serialize({
+			name: ['NS123', 'element'],
+			attributes: [
+				['myNs1', 'abc', '123'],
+				['myNs2', 'def', '456']
+			]
+		})).toEqual('<x0:element xmlns:x0="NS123" x1:abc="123" xmlns:x1="myNs1" x2:def="456" xmlns:x2="myNs2"/>');
+	});
+
 	it('should return correct xml for one element with attributes and value', () => {
 		expect(XMLUtility.serialize({
 			name: ['NS123', 'element'],
@@ -55,15 +65,12 @@ describe('XMLUtility', () => {
 	it('should prefer value over children', () => {
 		expect(XMLUtility.serialize({
 			name: ['NS123', 'element'],
-			attributes: [
-				['SPECIALNS', 'abc', '123'],
-				['def', '456']
-			],
+			attributes: [],
 			value: 'it value',
 			children: [{
 				name: 'element2'
 			}]
-		})).toEqual('<x0:element xmlns:x0="NS123" a0:abc="123" xmlns:a0="SPECIALNS" def="456">it value</x0:element>');
+		})).toEqual('<x0:element xmlns:x0="NS123">it value</x0:element>');
 	});
 
 	it('should return correct xml for one child', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,8 @@ export default createLibConfig({
 				headless: true,
 				provider: 'playwright',
 				instances: [
+					{ browser: 'webkit' },
+					{ browser: 'chromium' },
 					{ browser: 'firefox' },
 				],
 			},


### PR DESCRIPTION
I noticed two inconsistencies in XML serialization between different browsers.

The first I fixed in a10ba02441daf69aa17f1ca884b876c711721b3a.
The other I just documented after configuring tests to run with different browsers in f7163989344bca98368814a6052b20c4c6494d20.

Feel free to apply these changes if you find them useful.
Or just close this PR when you don't need them.