### PR TITLE
fix: send OPTIONS request to acquire advertised DAV features

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,13 +137,16 @@ export default class DavClient {
 			)
 		}
 
-		const response = await this._request.propFind(principalUrl, propFindList)
+		const [propFindResponse, optionsResponse] = await Promise.all([
+			this._request.propFind(principalUrl, propFindList),
+			this._request.options(principalUrl),
+		])
 
-		this.currentUserPrincipal = new Principal(null, this._request, principalUrl, response.body)
-		this._extractAdvertisedDavFeatures(response.headers)
-		this._extractAddressBookHomes(response.body)
-		this._extractCalendarHomes(response.body)
-		this._extractPrincipalCollectionSets(response.body)
+		this.currentUserPrincipal = new Principal(null, this._request, principalUrl, propFindResponse.body)
+		this._extractAdvertisedDavFeatures(optionsResponse.headers)
+		this._extractAddressBookHomes(propFindResponse.body)
+		this._extractCalendarHomes(propFindResponse.body)
+		this._extractPrincipalCollectionSets(propFindResponse.body)
 		this._createPublicCalendarHome()
 
 		this._isConnected = true

--- a/src/request.js
+++ b/src/request.js
@@ -35,6 +35,18 @@ export default class Request {
 	}
 
 	/**
+	 * sends an OPTIONS request
+	 *
+	 * @param {string} url - URL to do the request on
+	 * @param {object} headers - additional HTTP headers to send
+	 * @param {AbortSignal} abortSignal - the signal from an abort controller
+	 * @return {Promise<{body: string|object, status: number, headers: object}>}
+	 */
+	async options(url, headers = {}, abortSignal = null) {
+		return this.request('OPTIONS', url, headers, null, abortSignal)
+	}
+
+	/**
 	 * sends a GET request
 	 *
 	 * @param {string} url - URL to do the request on

--- a/test/unit/requestTest.js
+++ b/test/unit/requestTest.js
@@ -24,6 +24,45 @@ describe('Request', () => {
 		XMLUtility.resetPrefixMap()
 	})
 
+	it('should send OPTIONS requests', async () => {
+		const axiosRequestSpy = vi.spyOn(axios, 'request')
+			.mockResolvedValueOnce({
+				status: 234,
+				data: 567,
+			})
+
+		const parser = {
+			canParse: vi.fn(),
+			parse: vi.fn(),
+		}
+
+		const request = new Request('https://nextcloud.testing/nextcloud/remote.php/dav/', parser)
+		const response = await request.options('fooBar', {
+			Foo: 'Bar',
+			Bla: 'Blub',
+		})
+
+		expect(axiosRequestSpy).toHaveBeenCalledTimes(1)
+		expect(axiosRequestSpy).toHaveBeenCalledWith({
+			method: 'OPTIONS',
+			data: null,
+			url: 'https://nextcloud.testing/nextcloud/remote.php/dav/fooBar',
+			headers: expect.objectContaining({
+				Depth: '0',
+				'Content-Type': 'application/xml; charset=utf-8',
+				Foo: 'Bar',
+				Bla: 'Blub',
+			}),
+			validateStatus: expect.any(Function),
+			signal: null,
+		})
+
+		expect(response).toEqual({
+			body: 567,
+			status: 234,
+		})
+	})
+
 	it('should send GET requests', async () => {
 		const axiosRequestSpy = vi.spyOn(axios, 'request')
 			.mockResolvedValueOnce({


### PR DESCRIPTION
Fix https://github.com/nextcloud/cdav-library/issues/874

Send an OPTIONS request instead of reusing the PROPFIND response to acquire advertised DAV features.

---

> All DAV-compliant resources MUST return the DAV header with compliance-class "1" on all OPTIONS responses.

Ref https://datatracker.ietf.org/doc/html/rfc4918#section-10.1