### PR TITLE
fix: Clear internal list of updated properties on successful update

### DIFF
--- a/src/models/davCollection.js
+++ b/src/models/davCollection.js
@@ -185,8 +185,11 @@ export class DavCollection extends DAVEventListener {
 
 		dPropSet.push(...propSet)
 
-		const body = XMLUtility.serialize(skeleton)
-		await this._request.propPatch(this._url, {}, body)
+		if (propSet.length >= 1) {
+			const body = XMLUtility.serialize(skeleton)
+			await this._request.propPatch(this._url, {}, body)
+			this._updatedProperties = []
+		}
 	}
 
 	/**

--- a/src/models/principal.js
+++ b/src/models/principal.js
@@ -245,8 +245,11 @@ export class Principal extends DavObject {
 
 		dPropSet.push(...propSet)
 
-		const body = XMLUtility.serialize(skeleton)
-		await this._request.propPatch(this._url, {}, body)
+		if (propSet.length >= 1) {
+			const body = XMLUtility.serialize(skeleton)
+			await this._request.propPatch(this._url, {}, body)
+			this._updatedProperties = []
+		}
 	}
 
 }

--- a/test/unit/models/davCollectionTest.js
+++ b/test/unit/models/davCollectionTest.js
@@ -14,6 +14,7 @@ import DAVEventListener from "../../../src/models/davEventListener.js";
 import { DavObject } from "../../../src/models/davObject.js";
 import * as XMLUtility from '../../../src/utility/xmlUtility.js';
 import RequestMock from "../../mocks/request.mock.js";
+import NetworkRequestServerError from '../../../src/errors/networkRequestServerError.js'
 
 describe('Dav collection model', () => {
 
@@ -691,6 +692,95 @@ describe('Dav collection model', () => {
 		}).catch(() => {
 			assert.fail('DavCollection update was not supposed to assert.fail');
 		});
+	});
+
+	it('should clear the internal list of changed properties after a successful update', async () => {
+		const parent = {
+			'findAll': vi.fn(),
+			'findAllByFilter': vi.fn(),
+			'find': vi.fn(),
+			'createCollection': vi.fn(),
+			'createObject': vi.fn(),
+			'update': vi.fn(),
+			'delete': vi.fn(),
+			'isReadable': vi.fn(),
+			'isWriteable': vi.fn()
+		};
+		const request = new RequestMock();
+		const url = '/foo/bar/folder';
+		const props = {
+			'{DAV:}displayname': 'Foo Bar Bla Blub',
+			'{DAV:}owner': 'https://foo/bar/',
+			'{DAV:}resourcetype': ['{DAV:}collection'],
+			'{DAV:}sync-token': 'https://foo/bar/token/3',
+			'{custom}property': 'custom property value 123',
+			'{DAV:}current-user-privilege-set': ['{DAV:}write',
+				'{DAV:}write-properties', '{DAV:}write-content',
+				'{DAV:}unlock', '{DAV:}bind', '{DAV:}unbind',
+				'{DAV:}write-acl', '{DAV:}read', '{DAV:}read-acl',
+				'{DAV:}read-current-user-privilege-set'],
+		};
+
+		request.propPatch.mockImplementation(() => {
+			return Promise.resolve({
+				status: 207,
+				body: {
+					'{DAV:}displayname': 'test',
+					'{http://apple.com/ns/ical/}calendar-color': ''
+				},
+				headers: {}
+			});
+		});
+
+		const collection = new DavCollection(parent, request, url, props);
+		collection.displayname = 'test';
+
+		await collection.update();
+		await collection.update();
+		await collection.update();
+
+		expect(request.propPatch).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not clear the internal list of changed properties after an unsuccessful update', async () => {
+		const parent = {
+			'findAll': vi.fn(),
+			'findAllByFilter': vi.fn(),
+			'find': vi.fn(),
+			'createCollection': vi.fn(),
+			'createObject': vi.fn(),
+			'update': vi.fn(),
+			'delete': vi.fn(),
+			'isReadable': vi.fn(),
+			'isWriteable': vi.fn()
+		};
+		const request = new RequestMock();
+		const url = '/foo/bar/folder';
+		const props = {
+			'{DAV:}displayname': 'Foo Bar Bla Blub',
+			'{DAV:}owner': 'https://foo/bar/',
+			'{DAV:}resourcetype': ['{DAV:}collection'],
+			'{DAV:}sync-token': 'https://foo/bar/token/3',
+			'{custom}property': 'custom property value 123',
+			'{DAV:}current-user-privilege-set': ['{DAV:}write',
+				'{DAV:}write-properties', '{DAV:}write-content',
+				'{DAV:}unlock', '{DAV:}bind', '{DAV:}unbind',
+				'{DAV:}write-acl', '{DAV:}read', '{DAV:}read-acl',
+				'{DAV:}read-current-user-privilege-set'],
+		};
+
+		request.propPatch.mockImplementation(() => {
+			return Promise.reject(new NetworkRequestServerError({ status: 500 }));
+		});
+
+		const collection = new DavCollection(parent, request, url, props);
+		collection.displayname = 'test';
+
+		await expect(collection.update()).rejects.toThrow();
+		await expect(collection.update()).rejects.toThrow();
+		await expect(collection.update()).rejects.toThrow();
+
+		expect(request.propPatch).toHaveBeenCalledTimes(3);
 	});
 
 	it('should delete a collection', () => {

--- a/test/unit/models/principalTest.js
+++ b/test/unit/models/principalTest.js
@@ -14,6 +14,7 @@ import { Principal } from '../../../src/models/principal.js';
 import * as XMLUtility from '../../../src/utility/xmlUtility.js';
 import RequestMock from "../../mocks/request.mock.js";
 import { DavCollection as DavCollectionMock } from "../../mocks/davCollection.mock.js";
+import NetworkRequestServerError from '../../../src/errors/networkRequestServerError.js'
 
 describe('Principal model', () => {
 	beforeEach(() => {
@@ -498,5 +499,75 @@ describe('Principal model', () => {
 		}).catch(() => {
 			assert.fail('Principal update was not supposed to assert.fail');
 		});
+	});
+
+	it('should clear the internal list of changed properties after a successful update', async () => {
+		const parent = new DavCollectionMock();
+		const request = new RequestMock();
+		const url = '/nextcloud/remote.php/dav/foo/bar/baz/';
+		const props = {
+			'{DAV:}displayname': 'Umberto',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type': 'INDIVIDUAL',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-address-set': [],
+			'{DAV:}principal-URL': '/nextcloud/remote.php/dav/principals/users/user2/',
+			'{http://sabredav.org/ns}email-address': 'foo-bar@example.com',
+			'{urn:ietf:params:xml:ns:caldav}calendar-home-set': ['/nextcloud/remote.php/dav/calendars/admin/'],
+			'{urn:ietf:params:xml:ns:caldav}schedule-inbox-URL': '/nextcloud/remote.php/dav/calendars/admin/inbox/',
+			'{urn:ietf:params:xml:ns:caldav}schedule-outbox-URL': '/nextcloud/remote.php/dav/calendars/admin/outbox/',
+			'{urn:ietf:params:xml:ns:caldav}schedule-default-calendar-URL': '/nextcloud/remote.php/dav/calendars/admin/personal/',
+			'{urn:ietf:params:xml:ns:carddav}addressbook-home-set': ['/nextcloud/remote.php/dav/addressbooks/users/admin/'],
+		};
+
+		const principal = new Principal(parent, request, url, props);
+
+		request.propPatch.mockImplementation(() => {
+			return Promise.resolve({
+				status: 207,
+				body: {
+					'{urn:ietf:params:xml:ns:caldav}schedule-default-calendar-URL': '/nextcloud/remote.php/dav/calendars/admin/changed/',
+				},
+				headers: {}
+			});
+		});
+
+		principal.scheduleDefaultCalendarUrl = '/nextcloud/remote.php/dav/calendars/admin/changed/';
+
+		await principal.update();
+		await principal.update();
+		await principal.update();
+
+		expect(request.propPatch).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not clear the internal list of changed properties after an unsuccessful update', async () => {
+		const parent = new DavCollectionMock();
+		const request = new RequestMock();
+		const url = '/nextcloud/remote.php/dav/foo/bar/baz/';
+		const props = {
+			'{DAV:}displayname': 'Umberto',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type': 'INDIVIDUAL',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-address-set': [],
+			'{DAV:}principal-URL': '/nextcloud/remote.php/dav/principals/users/user2/',
+			'{http://sabredav.org/ns}email-address': 'foo-bar@example.com',
+			'{urn:ietf:params:xml:ns:caldav}calendar-home-set': ['/nextcloud/remote.php/dav/calendars/admin/'],
+			'{urn:ietf:params:xml:ns:caldav}schedule-inbox-URL': '/nextcloud/remote.php/dav/calendars/admin/inbox/',
+			'{urn:ietf:params:xml:ns:caldav}schedule-outbox-URL': '/nextcloud/remote.php/dav/calendars/admin/outbox/',
+			'{urn:ietf:params:xml:ns:caldav}schedule-default-calendar-URL': '/nextcloud/remote.php/dav/calendars/admin/personal/',
+			'{urn:ietf:params:xml:ns:carddav}addressbook-home-set': ['/nextcloud/remote.php/dav/addressbooks/users/admin/'],
+		};
+
+		const principal = new Principal(parent, request, url, props);
+
+		request.propPatch.mockImplementation(() => {
+			return Promise.reject(new NetworkRequestServerError({ status: 500 }));
+		});
+
+		principal.scheduleDefaultCalendarUrl = '/nextcloud/remote.php/dav/calendars/admin/changed/';
+
+		await expect(principal.update()).rejects.toThrow();
+		await expect(principal.update()).rejects.toThrow();
+		await expect(principal.update()).rejects.toThrow();
+
+		expect(request.propPatch).toHaveBeenCalledTimes(3);
 	});
 });


### PR DESCRIPTION
The `update` methods of a `davCollection` as well as `principal` should only include changed properties in the `PROPPATCH` request. This is handled by the internal `_updatedProperties` array, which should be cleared after the request was successful. As [discussed in my previous PR](https://github.com/nextcloud/cdav-library/pull/1029#discussion_r3161755934), this isn't the case right now and should be included to the existing methods as well.