### PR TITLE
fix: mocks with vitest v4

### DIFF
--- a/test/mocks/davCollection.mock.js
+++ b/test/mocks/davCollection.mock.js
@@ -5,17 +5,17 @@
 
 import { vi } from "vitest";
 
-const DavCollection = vi.fn()
-
-DavCollection.prototype.findAll = vi.fn();
-DavCollection.prototype.findAllByFilter = vi.fn();
-DavCollection.prototype.find = vi.fn();
-DavCollection.prototype.createCollection = vi.fn();
-DavCollection.prototype.createObject = vi.fn();
-DavCollection.prototype.update = vi.fn();
-DavCollection.prototype.delete = vi.fn();
-DavCollection.prototype.isReadable = vi.fn();
-DavCollection.prototype.isWriteable = vi.fn();
-DavCollection.prototype.isSameCollectionTypeAs = vi.fn();
+const DavCollection = vi.fn().mockImplementation(function() {
+	this.findAll = vi.fn();
+	this.findAllByFilter = vi.fn();
+	this.find = vi.fn();
+	this.createCollection = vi.fn();
+	this.createObject = vi.fn();
+	this.update = vi.fn();
+	this.delete = vi.fn();
+	this.isReadable = vi.fn();
+	this.isWriteable = vi.fn();
+	this.isSameCollectionTypeAs = vi.fn();
+});
 
 export { DavCollection };

--- a/test/mocks/request.mock.js
+++ b/test/mocks/request.mock.js
@@ -5,17 +5,17 @@
 
 import { vi } from "vitest";
 
-const Request = vi.fn()
-
-Request.prototype.propFind = vi.fn();
-Request.prototype.put = vi.fn();
-Request.prototype.post = vi.fn();
-Request.prototype.delete = vi.fn();
-Request.prototype.move = vi.fn();
-Request.prototype.copy = vi.fn();
-Request.prototype.report = vi.fn();
-Request.prototype.pathname = vi.fn();
-Request.prototype.propPatch = vi.fn();
-Request.prototype.mkCol = vi.fn();
+const Request = vi.fn().mockImplementation(function() {
+	this.propFind = vi.fn();
+	this.put = vi.fn();
+	this.post = vi.fn();
+	this.delete = vi.fn();
+	this.move = vi.fn();
+	this.copy = vi.fn();
+	this.report = vi.fn();
+	this.pathname = vi.fn();
+	this.propPatch = vi.fn();
+	this.mkCol = vi.fn();
+});
 
 export default Request


### PR DESCRIPTION
### Summary
- Fixed object mocks

### Issue
Both test/mocks/request.mock.js and test/mocks/davCollection.mock.js attached vi.fn() instances directly to the prototype. Vitest 4's changed module/pool isolation