### PR TITLE
feat: parse and persist plural default calendar alarms

### DIFF
--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -32,6 +32,8 @@ const debug = debugFactory('Calendar')
  * - timezone
  * - defaultAlarmPartDay
  * - defaultAlarmFullDay
+ * - defaultAlarmsPartDay
+ * - defaultAlarmsFullDay
  * - transparency
  * - components
  *
@@ -58,6 +60,8 @@ export class Calendar extends davCollectionPublishable(davCollectionShareable(Da
 		super._exposeProperty('transparency', NS.IETF_CALDAV, 'schedule-calendar-transp', true)
 		super._exposeProperty('defaultAlarmPartDay', NS.NEXTCLOUD, 'default-alarm-part-day', true)
 		super._exposeProperty('defaultAlarmFullDay', NS.NEXTCLOUD, 'default-alarm-full-day', true)
+		super._exposeProperty('defaultAlarmsPartDay', NS.NEXTCLOUD, 'default-alarms-part-day', true)
+		super._exposeProperty('defaultAlarmsFullDay', NS.NEXTCLOUD, 'default-alarms-full-day', true)
 	}
 
 	/**
@@ -288,6 +292,8 @@ export class Calendar extends davCollectionPublishable(davCollectionShareable(Da
 			[NS.OWNCLOUD, 'calendar-enabled'],
 			[NS.NEXTCLOUD, 'default-alarm-part-day'],
 			[NS.NEXTCLOUD, 'default-alarm-full-day'],
+			[NS.NEXTCLOUD, 'default-alarms-part-day'],
+			[NS.NEXTCLOUD, 'default-alarms-full-day'],
 			[NS.NEXTCLOUD, 'owner-displayname'],
 			[NS.NEXTCLOUD, 'trash-bin-retention-duration'],
 			[NS.NEXTCLOUD, 'deleted-at'],

--- a/src/parser.js
+++ b/src/parser.js
@@ -180,6 +180,8 @@ export default class Parser {
 		this.registerParser('{http://owncloud.org/ns}read-only', Parser.bool)
 		this.registerParser('{http://nextcloud.com/ns}default-alarm-part-day', Parser.decInt)
 		this.registerParser('{http://nextcloud.com/ns}default-alarm-full-day', Parser.decInt)
+		this.registerParser('{http://nextcloud.com/ns}default-alarms-part-day', Parser.defaultAlarms)
+		this.registerParser('{http://nextcloud.com/ns}default-alarms-full-day', Parser.defaultAlarms)
 		this.registerParser('{http://nextcloud.com/ns}owner-displayname', Parser.text)
 		this.registerParser('{http://nextcloud.com/ns}deleted-at', Parser.iso8601DateTime)
 		this.registerParser('{http://nextcloud.com/ns}calendar-uri', Parser.text)
@@ -595,6 +597,32 @@ export default class Parser {
 	 * @param {XPathNSResolver} resolver
 	 * @return {string[]}
 	 */
+	/**
+	 * Parses a {http://nextcloud.com/ns}default-alarms-* Node (JSON array of alarm templates)
+	 *
+	 * @param {Document} document
+	 * @param {Node} node
+	 * @param {XPathNSResolver} resolver
+	 * @return {Array|null}
+	 */
+	static defaultAlarms(document, node, resolver) {
+		const text = Parser.text(document, node, resolver)
+		if (text === null || text === '') {
+			return null
+		}
+
+		try {
+			const parsed = JSON.parse(text)
+			if (!Array.isArray(parsed) || parsed.length === 0) {
+				return null
+			}
+
+			return parsed
+		} catch (error) {
+			return null
+		}
+	}
+
 	static ocAccess(document, node, resolver) {
 		const result = []
 		const privileges = document.evaluate('oc:access/*', node, resolver, XPathResult.ANY_TYPE, null)

--- a/src/propset/calendarPropSet.js
+++ b/src/propset/calendarPropSet.js
@@ -20,6 +20,8 @@ import * as NS from '../utility/namespaceUtility.js'
  * - {http://owncloud.org/ns}calendar-enabled
  * - {http://nextcloud.com/ns}default-alarm-part-day
  * - {http://nextcloud.com/ns}default-alarm-full-day
+ * - {http://nextcloud.com/ns}default-alarms-part-day
+ * - {http://nextcloud.com/ns}default-alarms-full-day
  *
  * @param {object} props
  * @return {object}
@@ -83,6 +85,18 @@ export default function calendarPropSet(props) {
 			xmlified.push({
 				name: [NS.NEXTCLOUD, 'default-alarm-full-day'],
 				value,
+			})
+			break
+		case '{http://nextcloud.com/ns}default-alarms-part-day':
+			xmlified.push({
+				name: [NS.NEXTCLOUD, 'default-alarms-part-day'],
+				value: Array.isArray(value) ? JSON.stringify(value) : value,
+			})
+			break
+		case '{http://nextcloud.com/ns}default-alarms-full-day':
+			xmlified.push({
+				name: [NS.NEXTCLOUD, 'default-alarms-full-day'],
+				value: Array.isArray(value) ? JSON.stringify(value) : value,
 			})
 			break
 		case '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp':

--- a/test/unit/models/calendarTest.js
+++ b/test/unit/models/calendarTest.js
@@ -129,6 +129,23 @@ END:VCALENDAR
 		expect(calendar.defaultAlarmFullDay).toEqual(39600);
 	});
 
+	it('should inherit expose the property defaultAlarmsPartDay', () => {
+		const parent = new DavCollectionMock();
+		const request = new RequestMock();
+		const url = '/foo/bar/folder';
+		const props = returnDefaultProps();
+		props['{http://nextcloud.com/ns}default-alarms-part-day'] = [
+			{ trigger: -86400, action: 'EMAIL' },
+			{ trigger: -900, action: 'DISPLAY' },
+		];
+
+		const calendar = new Calendar(parent, request, url, props);
+		expect(calendar.defaultAlarmsPartDay).toEqual([
+			{ trigger: -86400, action: 'EMAIL' },
+			{ trigger: -900, action: 'DISPLAY' },
+		]);
+	});
+
 	it('should find all VObjects', () => {
 		const parent = new DavCollectionMock();
 		const request = new RequestMock();

--- a/test/unit/parserTest.js
+++ b/test/unit/parserTest.js
@@ -1907,6 +1907,31 @@ END:VALARM`);
 		expect(parser.parse(document, node, resolver)).toEqual(32400);
 	});
 
+	it('should properly handle {http://nextcloud.com/ns}default-alarms-part-day', () => {
+		const parser = new Parser();
+
+		const xml = `<?xml version="1.0" encoding="utf-8" ?>
+<D:multistatus xmlns:D="DAV:" xmlns:nc="http://nextcloud.com/ns">
+	<D:response>
+		<D:href>/foo</D:href>
+		<D:propstat>
+			<D:prop>
+				<nc:default-alarms-part-day>[{"trigger":-86400,"action":"EMAIL"},{"trigger":-900,"action":"DISPLAY"}]</nc:default-alarms-part-day>
+			</D:prop>
+			<D:status>HTTP/1.1 200 OK</D:status>
+		</D:propstat>
+	</D:response>
+</D:multistatus>`;
+
+		const [document, node, resolver] = getDocumentNodeResolverFromXML(xml);
+
+		expect(parser.canParse('{http://nextcloud.com/ns}default-alarms-part-day')).toEqual(true);
+		expect(parser.parse(document, node, resolver)).toEqual([
+			{ trigger: -86400, action: 'EMAIL' },
+			{ trigger: -900, action: 'DISPLAY' },
+		]);
+	});
+
 	it('should properly handle {http://nextcloud.com/ns}default-alarm-full-day', () => {
 		const parser = new Parser();
 

--- a/test/unit/propset/calendarPropSetTest.js
+++ b/test/unit/propset/calendarPropSetTest.js
@@ -131,6 +131,21 @@ describe('Calendar prop-set', () => {
 		]);
 	});
 
+	it('should serialize {http://nextcloud.com/ns}default-alarms-part-day correctly', () => {
+		const alarms = [
+			{ trigger: -86400, action: 'EMAIL' },
+			{ trigger: -900, action: 'DISPLAY' },
+		];
+		expect(calendarPropSet({
+			'{http://nextcloud.com/ns}default-alarms-part-day': alarms,
+		})).toEqual([
+			{
+				name: ['http://nextcloud.com/ns', 'default-alarms-part-day'],
+				value: JSON.stringify(alarms),
+			},
+		]);
+	});
+
 	it('should serialize {urn:ietf:params:xml:ns:caldav}schedule-calendar-transp correctly - transparent', () => {
 		expect(calendarPropSet({
 			'{Foo:}bar': 123,


### PR DESCRIPTION
This PR is hand-written (other than the commit comment below, which was edited by me), but the code changes were created by AI.

I am a novice at PHP and new to Nextcloud development so I invite scrutiny.  Everything was reviewed and tested by me with both the stable server and the new app+lib, plus the stable app and the new server.

The intent of this feature is to extend the recent default calendar reminder feature by allowing multiple reminders to be set as well as the notification type for each.  Only relative reminder intervals are supported as I didn't think absolute reminders made much sense in a template.  This requires changes in server, cdav-library, and the calendar app.  

The server revisions are backwards-compatible with the current stable app, and the app revisions are backwards-compatible with the current stable server.  This library should work with both the current stable app and the revised app, though the revised app does require this update.

This is related to:
https://github.com/nextcloud/calendar/pull/8567
https://github.com/nextcloud/server/pull/61832

Commit comment:
Expose defaultAlarmsPartDay/defaultAlarmsFullDay on the Calendar model with JSON array parsing and PROPPATCH serialization for the new CalDAV properties default-alarms-part-day and default-alarms-full-day.

Assisted-by: Grok:grok-4



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
